### PR TITLE
Light refactoring and testing

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -37,18 +37,16 @@
 
 
 import contextlib
+import ftplib
 import gzip
 import os
-import shutil
 import re
+import shutil
 import sys
-import ftplib
 
 from urllib.request import urlopen
 from urllib.request import urlretrieve
 from urllib.request import urlcleanup
-
-from requests import codes
 
 
 class PDBList:
@@ -272,7 +270,7 @@ class PDBList:
             "mmCif": "%s.cif.gz",
             "xml": "%s.xml.gz",
             "mmtf": "%s",
-            "bundle": "%s-pdb-bundle.tar.gz"
+            "bundle": "%s-pdb-bundle.tar.gz",
         }
         archive_fn = archive[file_format] % code
 
@@ -303,7 +301,7 @@ class PDBList:
                 code[1:3],
                 code,
                 archive_fn,
-            )             
+            )
         else:
             url = f"http://mmtf.rcsb.org/v1.0/full/{code}"
 
@@ -322,7 +320,7 @@ class PDBList:
             "mmCif": "%s.cif",
             "xml": "%s.xml",
             "mmtf": "%s.mmtf",
-            "bundle": "%s-pdb-bundle.tar"
+            "bundle": "%s-pdb-bundle.tar",
         }
         final_file = os.path.join(path, final[file_format] % code)
 
@@ -348,7 +346,7 @@ class PDBList:
             os.remove(filename)
         return final_file
 
-    def update_pdb(self, file_format=None):
+    def update_pdb(self, file_format=None, with_assemblies=False):
         """Update your local copy of the PDB files.
 
         I guess this is the 'most wanted' function from this module.
@@ -367,12 +365,27 @@ class PDBList:
         for pdb_code in new + modified:
             try:
                 self.retrieve_pdb_file(pdb_code, file_format=file_format)
-            except Exception:
-                print(f"error {pdb_code}\n")
+                if with_assemblies:
+                    assemblies = self.get_all_assemblies(file_format)
+                    for a_pdb_code, assembly_num in assemblies:
+                        if a_pdb_code == pdb_code:
+                            pl.retrieve_assembly_file(
+                                pdb_code,
+                                assembly_num,
+                                file_format=file_format,
+                                overwrite=True,
+                            )
+
+            except Exception as err:
+                print(f"error {pdb_code}: {err}\n")
                 # you can insert here some more log notes that
                 # something has gone wrong.
 
         # Move the obsolete files to a special folder
+        # NOTE: This should be updated to handle multiple file types and
+        # assemblies. As of now, it only looks for PDB-formatted files.
+        # Using pathlib will be probably the best approach here, to build
+        # and index of which files we have efficiently (or glob them).
         for pdb_code in obsolete:
             if self.flat_tree:
                 old_file = os.path.join(self.local_pdb, f"pdb{pdb_code}.ent")
@@ -445,90 +458,161 @@ class PDBList:
                 file_format=file_format,
                 overwrite=overwrite,
             )
-    
-    def fetch_assembly_list(
-        self, pdb_codes, file_format=None,
+
+    def get_all_assemblies(self, file_format="mmCif"):
+        """Retrieve the list of PDB entries with an associated bio assembly.
+
+        The requested list will be cached to avoid multiple calls to the FTP
+        server.
+
+        :type  file_format: str, optional
+        :param file_format: format in which to download the entries. Available
+            options are "mmCif" or "pdb". Defaults to mmCif.
+        """
+        if hasattr(self, "assemblies") and self.assemblies:
+            if self._verbose:
+                print("Retrieving cached list of assemblies.")
+            return self.assemblies  # cache
+
+        if self._verbose:
+            print("Retrieving list of assemblies. This might take a while.")
+
+        # FTPLib is much faster than urlopen
+        idx = self.pdb_server.find("://")
+        if idx >= 0:
+            ftp = ftplib.FTP(self.pdb_server[idx + 3 :])
+        else:
+            ftp = ftplib.FTP(self.pdb_server)
+        ftp.login()  # anonymous
+
+        if file_format.lower() == "mmcif":
+            ftp.cwd("/pub/pdb/data/assemblies/mmCIF/all/")
+            re_name = re.compile(r"(\d[0-9a-z]{3})-assembly(\d+).cif.gz")
+        elif file_format.lower() == "pdb":
+            ftp.cwd("/pub/pdb/data/biounit/PDB/all/")
+            re_name = re.compile(r"(\d[0-9a-z]{3}).pdb(\d+).gz")
+        else:
+            msg = "file_format for assemblies must be 'pdb' or 'mmCif'"
+            raise ValueError(msg)
+
+        response = []
+        ftp.retrlines("NLST", callback=response.append)
+        # PDB entries can have more than one assembly:
+        #  e.g.
+        #    104l-assembly1.cif.gz           2022-01-15 19:38   36K
+        #    104l-assembly2.cif.gz           2022-01-15 19:38   36K
+        #    ...
+        #    104l.pdb1.gz               2010-01-15 08:00   28K
+        #    104l.pdb2.gz               2010-01-15 08:00   28K
+        all_assemblies = []
+        for line in response:
+            if line.endswith(".gz"):
+                match = re_name.findall(line)
+                try:
+                    if len(match):
+                        entry, assembly = match[0]
+                except ValueError:
+                    pass
+                else:
+                    all_assemblies.append((entry, assembly))
+        self.assemblies = all_assemblies  # cache
+        return all_assemblies
+
+    def retrieve_assembly_file(
+        self, pdb_code, assembly_num, pdir=None, file_format=None, overwrite=False
     ):
-        """
-        Fetch list of assemblies to download
-        """
-        assemblies_to_fetch = []
+        """Fetch one or more assembly structures associated with a PDB entry.
 
-        if isinstance(pdb_codes, str):
-            pdb_codes = [pdb_codes.lower()]
-        
-        print(f"Fetching assemblies associated with PDB ID(s) '{', '.join(pdb_codes).lower()}'...")
-        for code in pdb_codes:
-            code = code.lower()
-            ftp = ftplib.FTP("ftp.wwpdb.org")
-            ftp.login()  # anonymous
-            division = code[1:3]
-            if file_format.lower() == 'pdb':
-                ftp.cwd(f"pub/pdb/data/biounit/PDB/divided/{division}")
-            else:
-                ftp.cwd(f"pub/pdb/data/biounit/mmCIF/divided/{division}")
-            # else:
-            #     ftp.cwd("pub/pdb/data/assemblies/mmCIF/divided/{division}") # For May
-            entries = []
-            ftp.retrlines("NLST", callback=entries.append)
-            assemblies_tmp = [e for e in entries if code in e]
-            if len(assemblies_tmp) == 0:
-                raise OSError(f"No assembly for '{code}' in the desired format")
-            else:
-                assemblies_to_fetch += assemblies_tmp
-            
-        return assemblies_to_fetch
+        Unless noted below, parameters are described in ``retrieve_pdb_file``.
 
-    def retrieve_assembly(
-        self, assembly_in, pdir=None, file_format=None, overwrite=False
-    ):
+        :type  assembly_num: int
+        :param assembly_num: assembly number to download.
+
+        :rtype : str
+        :return: file name of the downloaded assembly file.
         """
-        Fetch assembly for specified PDB code.
+        archive = {
+            "pdb": "%s-pdb%s.gz",
+            "mmcif": "%s-assembly%s.cif.gz",
+        }
 
-        Rest of docstring todo.
-        """
-        code = assembly_in[:4]
+        file_format = self._print_default_format_warning(file_format)
+        file_format = file_format.lower()  # we should standardize this.
+        if file_format not in archive:
+            raise (
+                "Specified file_format '%s' is not supported. Use one of the "
+                "following: 'mmcif' or 'pdb'." % file_format
+            )
 
+        # Get the compressed assembly structure name
+        archive_fn = archive[file_format] % (pdb_code.lower(), int(assembly_num))
+
+        if file_format == "mmcif":
+            url = self.pdb_server + "/pub/pdb/data/assemblies/mmCIF/all/%s" % archive_fn
+        elif file_format == "pdb":
+            url = self.pdb_server + "/pub/pdb/data/biounit/PDB/all/%s" % archive_fn
+        else:  # better safe than sorry
+            raise ValueError("file_format '%s' not supported: %s" % file_format)
+
+        # Where will the file be saved?
         if pdir is None:
             path = self.local_pdb
             if not self.flat_tree:  # Put in PDB-style directory tree
-                path = os.path.join(path, code[1:3])
+                path = os.path.join(path, pdb_code[1:3])
         else:  # Put in specified directory
             path = pdir
         if not os.access(path, os.F_OK):
             os.makedirs(path)
 
-        final_assembly_file = os.path.join(path, assembly_in[:-3])
+        assembly_gz_file = os.path.join(path, archive_fn)
+        assembly_final_file = os.path.join(path, archive_fn[:-3])  # no .gz
+
         # Skip download if the file already exists
         if not overwrite:
-            if os.path.exists(final_assembly_file):
+            if os.path.exists(assembly_final_file):
                 if self._verbose:
-                    print(f"Assembly exists: '{final_assembly_file}' ")
-                return final_assembly_file
+                    print(f"Structure exists: '{assembly_final_file}' ")
+                return assembly_final_file
 
-        if file_format=='pdb':
-            number = assembly_in[8]
-            assembly_url = f"http://ftp.wwpdb.org/pub/pdb/data/biounit/PDB/all/{assembly_in}"
-            assembly_filename = os.path.join(path, assembly_in)
-        else:
-            number = assembly_in[-8]
-            assembly_url = f"http://ftp.wwpdb.org/pub/pdb/data/biounit/mmCIF/all/{assembly_in}"
-            assembly_filename = os.path.join(path, assembly_in)
-        # try:
+        # Otherwise,retrieve the file(s)
         if self._verbose:
-            print(f"Downloading '{code}' assembly {number}...")
+            print(
+                f"Downloading assembly ({assembly_num}) for PDB entry "
+                f"'{pdb_code}'..."
+            )
+        try:
+            urlcleanup()
+            urlretrieve(url, assembly_gz_file)
+        except OSError as err:
+            print(
+                f"Download failed! Maybe the desired assembly does not exist: {err}"
+            )
+        else:
+            with gzip.open(assembly_gz_file, "rb") as gz:
+                with open(assembly_final_file, "wb") as out:
+                    out.writelines(gz)
+            os.remove(assembly_gz_file)
+        return assembly_final_file
 
-        urlcleanup()
-        urlretrieve(assembly_url, assembly_filename)
-        # except OSError:
-        #     print("Desired assembly doesn't exist")  # I don't think we need this try/except since I take care of that in the fetch
-        # else:
+    def download_all_assemblies(self, listfile=None, file_format=None):
+        """Retrieve all biological assemblies not in the local PDB copy.
 
-        with gzip.open(assembly_filename, "rb") as gz:
-            with open(final_assembly_file, "wb") as out:
-                out.writelines(gz)
-        os.remove(assembly_filename)
-        return final_assembly_file
+        :type  listfile: str, optional
+        :param listfile: file name to which all assembly codes will be written
+
+        :type  file_format: str, optional
+        :param file_format: format in which to download the entries. Available
+            options are "mmCif" or "pdb". Defaults to mmCif.
+        """
+        # Deprecation warning
+        file_format = self._print_default_format_warning(file_format)
+        assemblies = self.get_all_assemblies(file_format)
+        for pdb_code, assembly_num in assemblies:
+            self.retrieve_assembly_file(pdb_code, assembly_num, file_format=file_format)
+        # Write the list
+        if listfile:
+            with open(listfile, "w") as outfile:
+                outfile.writelines(f"{pdb_code}.{assembly_num}\n" for x in assemblies)
 
     def download_entire_pdb(self, listfile=None, file_format=None):
         """Retrieve all PDB entries not present in the local PDB copy.
@@ -601,6 +685,8 @@ if __name__ == "__main__":
                                                    local pdb tree.
         PDBList.py obsol  <pdb_path> [options]   - write all obsolete PDB
                                                    entries to local pdb tree.
+        PDBList.py assemb <pdb_path> [options]   - write all assemblies for each
+                                                   PDB entry to local pdb tree.
         PDBList.py <PDB-ID> <pdb_path> [options] - retrieve single structure
         PDBList.py (<PDB-ID1>,<PDB-ID2>,...) <pdb_path> [options] - retrieve a set
                                                    of structures
@@ -611,6 +697,7 @@ if __name__ == "__main__":
      -pdb     Downloads structures in PDB format
      -xml     Downloads structures in PDBML (XML) format
      -mmtf    Downloads structures in mmtf format
+     -with-assemblies    Downloads assemblies along with regular entries.
 
     Maximum one format can be specified simultaneously (if more selected, only
     the last will be considered). By default (no format specified) structures are
@@ -620,8 +707,7 @@ if __name__ == "__main__":
 
     file_format = "mmCif"
     overwrite = False
-    assemblies = False
-    assemblies_only = False
+    with_assemblies = False
 
     if len(sys.argv) > 2:
         pdb_path = sys.argv[2]
@@ -635,12 +721,8 @@ if __name__ == "__main__":
                 elif option in ("-pdb", "-xml", "-mmtf"):
                     file_format = option[1:]
                 # Allow for download of assemblies alongside ASU
-                elif option == "-assemblies":
-                    assemblies = True
-                # Allow for download of assemblies alone
-                elif option == "-assemblies-only":
-                    assemblies_only = True
-
+                elif option == "-with-assemblies":
+                    with_assemblies = True
 
     else:
         pdb_path = os.getcwd()
@@ -656,45 +738,53 @@ if __name__ == "__main__":
         elif sys.argv[1] == "all":
             # get the entire PDB
             pl.download_entire_pdb(file_format=file_format)
+            if with_assemblies:
+                # get all assembly structures
+                pl.download_all_assemblies(file_format=file_format)
 
         elif sys.argv[1] == "obsol":
             # get all obsolete entries
             pl.download_obsolete_entries(pdb_path, file_format=file_format)
 
+        elif sys.argv[1] == "assemb":
+            # get all assembly structures
+            pl.download_all_assemblies(file_format=file_format)
+
         elif len(sys.argv[1]) == 4 and sys.argv[1][0].isdigit():
+            pdb_code = sys.argv[1]
             # get single PDB entry
-            if assemblies or assemblies_only:
-                fetch_output = pl.fetch_assembly_list(sys.argv[1], file_format=file_format
+            pl.retrieve_pdb_file(
+                pdb_code, pdir=pdb_path, file_format=file_format, overwrite=overwrite
             )
-            if assemblies_only:
-                for assembly in fetch_output:
-                        pl.retrieve_assembly(assembly, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
-            else:
-                if assemblies:
-                    for assembly in fetch_output:
-                        pl.retrieve_assembly(assembly, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
-                pl.retrieve_pdb_file(
-                    sys.argv[1], pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
+            if with_assemblies:
+                # PDB Code might have more than one assembly.
+                assemblies = pl.get_all_assemblies(file_format)
+                for a_pdb_code, assembly_num in assemblies:
+                    if a_pdb_code == pdb_code:
+                        pl.retrieve_assembly_file(
+                            pdb_code,
+                            assembly_num,
+                            pdir=pdb_path,
+                            file_format=file_format,
+                            overwrite=overwrite,
+                        )
 
         elif sys.argv[1][0] == "(":
             # get a set of PDB entries
             pdb_ids = re.findall("[0-9A-Za-z]{4}", sys.argv[1])
-            if assemblies or assemblies_only:
-                    fetch_output = pl.fetch_assembly_list(pdb_ids, file_format=file_format
-            )
-            if assemblies_only:
-                for assembly in fetch_output:
-                    pl.retrieve_assembly(assembly, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
-            else:
-                if assemblies:
-                    for assembly in fetch_output:
-                        pl.retrieve_assembly(assembly, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
-                for pdb_id in pdb_ids:
-                    pl.retrieve_pdb_file(
-                        pdb_id, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
+            for pdb_id in pdb_ids:
+                pl.retrieve_pdb_file(
+                    pdb_id, pdir=pdb_path, file_format=file_format, overwrite=overwrite
+                )
+                if with_assemblies:
+                    # PDB Code might have more than one assembly.
+                    assemblies = pl.get_all_assemblies(file_format)
+                    for a_pdb_code, assembly_num in assemblies:
+                        if a_pdb_code == pdb_id:
+                            pl.retrieve_assembly_file(
+                                pdb_id,
+                                assembly_num,
+                                pdir=pdb_path,
+                                file_format=file_format,
+                                overwrite=overwrite,
+                            )

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -733,7 +733,7 @@ if __name__ == "__main__":
         if sys.argv[1] == "update":
             # update PDB
             print("updating local PDB at " + pdb_path)
-            pl.update_pdb(file_format=file_format)
+            pl.update_pdb(file_format=file_format, with_assemblies=with_assemblies)
 
         elif sys.argv[1] == "all":
             # get the entire PDB


### PR DESCRIPTION
Hi @sean-workman 

Finally, my comments/changes. Thanks for doing all the heavy work here, I renamed stuff and moved it around but if you pay close attention you'll see that it's mostly your code and logic. The "bigger" change is that I simplified the access to downloading assemblies with an "assemb" option and an "-with-assemblies" option. The first is a "mode" of the script that simply downloads all assemblies and the latter is an option that can be used along with downloading a single PDB file, multiple, with "update", or with "all". This would be a lot nicer if we used argparse and subcommands, but not to mess up the user-facing interface, I left it as is.

I also noticed a couple of problems with the code (not yours, in general with the script). I'm writing them here to leave a paper trail:
- The pdb server addresses will not work with EBI links, because the root does not contain 'pub/pdb', e.g. `https://ftp.ebi.ac.uk/pub/databases/pdb/data/`.
- The obsolete mode/option will only work for files in PDB format. For example, in the update function, it will not move obsolete mmCIF files.
- The file names, file formats, and all that code to map and deduce file names should be really stored in a couple of module-level dicts/enums for re-use and simplicity.
- The user interface is incredibly clunky as it is now, with all that mangling of `sys.argv`. It should be refactored cleanly to use `argparse` and probably subcommands.

Back to you, whenever you have time to review! I'll test this in the coming days with a few more exhaustive tests, but I think it's pretty much done!